### PR TITLE
Use name variable in jmxtrans init.d template

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,7 @@ template "/etc/init.d/jmxtrans" do
   owner "root"
   group "root"
   mode  "0755" 
+  variables( :name => "jmxtrans")
  notifies :restart, "service[jmxtrans]"
 end
 

--- a/templates/default/jmxtrans.init.deb.erb
+++ b/templates/default/jmxtrans.init.deb.erb
@@ -1,23 +1,24 @@
 #!/bin/bash
 
 ### BEGIN INIT INFO
-# Provides:     @PACKAGE@
+# Provides:     <%= @name %>
 # Required-Start:  $time $network $remote_fs $syslog
 # Required-Stop:   $time $network $remote_fs $syslog
 # Default-Start:    2 3 4 5
 # Default-Stop:     0 1 6
-# Short-Description:    @PACKAGE@
+# Short-Description:    <%= @name %>
 ### END INIT INFO
 
 . /lib/lsb/init-functions
 
-if [ -f /etc/default/@PACKAGE@ ]; then
-    source /etc/default/@PACKAGE@
+NAME=<%= @name %>
+if [ -f /etc/default/$NAME ]; then
+    source /etc/default/$NAME
 fi
 
-PIDFILE="/var/run/@PACKAGE@.pid"
+PIDFILE="/var/run/$NAME.pid"
 
-RUNCMD="if [ -f /etc/default/@PACKAGE@ ]; then source /etc/default/@PACKAGE@ ; fi ; \
+RUNCMD="if [ -f /etc/default/$NAME ]; then source /etc/default/$NAME ; fi ; \
           cd <%= node['jmxtrans']['home'] %> ; \
           ./jmxtrans.sh"
 
@@ -38,30 +39,30 @@ do_status() {
 
 case "$1" in
   start)
-    log_daemon_msg "Starting @PACKAGE@" "@PACKAGE@"
+    log_daemon_msg "Starting $NAME" "$NAME"
     do_start
     log_end_msg 0
     ;;
   stop)
-    log_daemon_msg "Stopping @PACKAGE@" "@PACKAGE@"
+    log_daemon_msg "Stopping $NAME" "$NAME"
     do_stop
     log_end_msg 0
     ;;
 
   restart|reload|force-reload|try-restart)
-    log_daemon_msg "Restarting @PACKAGE@" "@PACKAGE@"
+    log_daemon_msg "Restarting $NAME" "$NAME"
     do_stop
     do_start
     log_end_msg 0
     ;;
 
   status)
-    log_daemon_msg "Status @PACKAGE@" "@PACKAGE@"
+    log_daemon_msg "Status $NAME" "$NAME"
     do_status
     log_end_msg 0
     ;;
 
   *)
-    log_action_msg "Usage: /etc/init.d/@PACKAGE@ {start|stop|reload|force-reload|restart|try-restart|status}"
+    log_action_msg "Usage: /etc/init.d/$NAME {start|stop|reload|force-reload|restart|try-restart|status}"
     exit 1
 esac


### PR DESCRIPTION
Inspired by your tomcat cookbook, if not /etc/default/jmxtrans is not loaded.
