### PR TITLE
included_recipe ark to make it install unzip first

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,7 @@
 # Apache 2.0 license
 #
 
+include_recipe "ark"
 
 if platform_family?("debian")
   init_script_file = "jmxtrans.init.deb.erb"


### PR DESCRIPTION
As discussed on irc - there is a dependency on ark but as it is not included in the recipe, the package unzip is not installed before the recipe. This commit fixes it by include_recipe in the default.rb
