### PR TITLE
Updated attribute assignment to be chef 11 compatible

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,9 +18,9 @@ end
 user node['jmxtrans']['user']
 
 # merge stock jvm queries w/ container specific ones into single array
-servers = node['jmxtrans']['servers']
+servers = node.normal['jmxtrans']['servers']
 servers.each do |server|
-  server['queries'] = node['jmxtrans']['default_queries']['jvm']
+  server['queries'] << node['jmxtrans']['default_queries']['jvm']
   case server['type']
   when 'tomcat'
     server['queries'] << node['jmxtrans']['default_queries']['tomcat']


### PR DESCRIPTION
The old attribute assignment behavior in this recipe isn't compatible w/ chef 11 - this PR changes that behavior to be compatible. It appears to work in my basic tests. 
