### PR TITLE
work around 'Exception::ImmutableAttributeModification'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a name="title"></a> chef-jmxtrans[![Build Status](https://secure.travis-ci.org/bryanwb/chef-jmxtrans.png?branch=master)](http://travis-ci.org/bryanwb/chef-jmxtrans)
+# chef-jmxtrans
 
 
 Description

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,8 @@ default['jmxtrans']['run_interval'] = '60'
 default['jmxtrans']['log_level'] = 'debug'
 default['jmxtrans']['graphite']['host'] = 'graphite'
 default['jmxtrans']['graphite']['port'] = '2003'
+default['jmxtrans']['rmi_response_timeout'] = 3000
+
 
 default['jmxtrans']['servers'] = []
 default['jmxtrans']['root_prefix'] = "jmx"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@ end
 user node['jmxtrans']['user']
 
 # merge stock jvm queries w/ container specific ones into single array
-servers = node['jmxtrans']['servers']
+servers = node['jmxtrans']['servers'].dup
 servers.each do |server|
   server['queries'] = node['jmxtrans']['default_queries']['jvm']
   case server['type']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,7 +15,9 @@ elsif platform_family?("rhel")
   init_script_file = "jmxtrans.init.el.erb"
 end
 
-user node['jmxtrans']['user']
+user node['jmxtrans']['user'] do
+  shell "/bin/bash"
+end
 
 # merge stock jvm queries w/ container specific ones into single array
 servers = node['jmxtrans']['servers'].dup

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,9 @@ end
 # merge stock jvm queries w/ container specific ones into single array
 servers = node['jmxtrans']['servers'].dup
 servers.each do |server|
+  if !server.key?('queries')
+    server['queries'] = []
+  end
   server['queries'] << node['jmxtrans']['default_queries']['jvm']
   case server['type']
   when 'tomcat'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@ user node['jmxtrans']['user']
 # merge stock jvm queries w/ container specific ones into single array
 servers = node['jmxtrans']['servers'].dup
 servers.each do |server|
-  server['queries'] = node['jmxtrans']['default_queries']['jvm']
+  server['queries'] << node['jmxtrans']['default_queries']['jvm']
   case server['type']
   when 'tomcat'
     server['queries'] << node['jmxtrans']['default_queries']['tomcat']

--- a/templates/default/jmxtrans_default.erb
+++ b/templates/default/jmxtrans_default.erb
@@ -7,4 +7,4 @@ export NEW_SIZE=64
 export CPU_CORES=<%= node['cpu']['total'] %>
 export NEW_RATIO=8
 export LOG_LEVEL=<%= node['jmxtrans']['log_level'] %>
-
+export JMXTRANS_OPTS="-Dsun.rmi.transport.tcp.responseTimeout=<%= node['jmxtrans']['rmi_response_timeout'] %>"


### PR DESCRIPTION
Running this recipe under chef-11.8.0 I get this:

```
Chef::Exceptions::ImmutableAttributeModification
------------------------------------------------
Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["key"] = "value"'


Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/jmxtrans/recipes/default.rb:23:in `block in from_file'
  /var/chef/cache/cookbooks/jmxtrans/recipes/default.rb:22:in `each'
  /var/chef/cache/cookbooks/jmxtrans/recipes/default.rb:22:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/jmxtrans/recipes/default.rb:

 16:  end
 17:  
 18:  user node['jmxtrans']['user']
 19:  
 20:  # merge stock jvm queries w/ container specific ones into single array
 21:  servers = node['jmxtrans']['servers']
 22:  servers.each do |server|
 23>>   server['queries'] = node['jmxtrans']['default_queries']['jvm']
 24:    case server['type']
 25:    when 'tomcat'
 26:      server['queries'] << node['jmxtrans']['default_queries']['tomcat']
 27:    end
 28:    server['queries'].flatten!
 29:  end
 30:  
 31:  ark "jmxtrans" do
 32:    url node['jmxtrans']['url']
```

Since it is the only place where we refer to node['jmxtrans']['servers'] attribute in recipe - .dup can be used to work it around (I hope).
